### PR TITLE
Add Weekly Cron Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]" 2>/dev/null || pip install -e . && pip install pytest
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+        run: uv python install 3.12
 
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev]" 2>/dev/null || pip install -e . && pip install pytest
+        run: uv sync --dev
 
       - name: Run tests
-        run: |
-          pytest tests/ -v
+        run: uv run pytest tests/ -v

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,36 @@
+name: Weekly Macro Analysis
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Every Monday at 08:00 AM UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to commit/push if we decide to save results to repo
+      
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          
+      - name: Install dependencies
+        run: |
+          pip install .
+          
+      - name: Run Analysis Pipeline
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          mie run
+          
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysis-results
+          path: dump/

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,26 +9,25 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Needed to commit/push if we decide to save results to repo
-      
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
-      
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          
+        run: uv python install 3.12
+
       - name: Install dependencies
-        run: |
-          pip install .
-          
+        run: uv sync
+
       - name: Run Analysis Pipeline
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: |
-          mie run
-          
+        run: uv run mie run
+
       - name: Archive Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/src/mie/cli.py
+++ b/src/mie/cli.py
@@ -132,6 +132,10 @@ def _cmd_add(args: argparse.Namespace) -> None:
         print(f"Failed to resolve channel: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    if info is None:
+        print("Could not retrieve channel info.", file=sys.stderr)
+        sys.exit(1)
+
     channel_id = info.get("channel_id") or ""
     channel_name = info.get("channel") or info.get("uploader") or ""
 


### PR DESCRIPTION
Added GitHub Actions workflow for weekly analysis.

- Runs every Monday at 08:00 AM UTC.
- Can be triggered manually.
- Installs dependencies and runs `mie run`.
- Uploads `dump/` directory as an artifact.